### PR TITLE
docs(readme): update getting started instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ npm install --save-dev postcss-loader postcss
 
 Then add the plugin to your `webpack` config. For example:
 
+> In the following configuration the plugin [`postcss-preset-env`](https://github.com/csstools/postcss-preset-env) is used, which is not installed by default.
+
 **file.js**
 
 ```js


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

In the [Getting Started section](https://webpack.js.org/loaders/postcss-loader/#getting-started), it should tell you to also install postcss-preset-env because in the provided boilerplate-configuration, the plugin is used.
This line npm install --save-dev postcss-loader postcss should change to npm install --save-dev postcss-loader postcss postcss-preset-env.
Closes #548.

### Breaking Changes

<!--
  If this PR introduces a breaking change, please describe the impact and a
  migration path for existing applications.
-->

### Additional Info
