### PR TITLE
fix: cannot find module 'ts-node'

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,17 @@
   ],
   "peerDependencies": {
     "postcss": "^7.0.0 || ^8.0.1",
-    "webpack": "^5.0.0"
+    "webpack": "^5.0.0",
+    "ts-node": ">=10",
+    "typescript": ">=4"
+  },
+  "peerDependenciesMeta": {
+    "ts-node": {
+      "optional": true
+    },
+    "typescript": {
+      "optional": true
+    }
   },
   "dependencies": {
     "cosmiconfig": "^8.1.3",


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [x] **bugfix**
- [ ] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

<!--
  Please explain the motivation or use-case for your change.
  What existing problem does the PR solve?
  If this PR addresses an issue, please link to the issue.
-->

Working with yarn or later npm versions, or pnp, etc.  Anything not 5 years old package managers.

### Additional Info

Fixes #636

Note: this will still be needed, even when https://github.com/Codex-/cosmiconfig-typescript-loader/issues/79 is resolved


`cosmiconfig-typescript-loader` peerDeps must be satisfied at any level it is included. Since it was added as a dependency, we must ensure they are specified so they can be resolved.

https://github.com/Codex-/cosmiconfig-typescript-loader/blob/main/package.json#LL39C6-L39C13 is the peerDeps